### PR TITLE
Mods

### DIFF
--- a/openstack/blockstorage/v2/volumes/results.go
+++ b/openstack/blockstorage/v2/volumes/results.go
@@ -55,6 +55,8 @@ type Volume struct {
 	ConsistencyGroupID string `json:"consistencygroup_id"`
 	// Multiattach denotes if the volume is multi-attach capable.
 	Multiattach bool `json:"multiattach"`
+	// VolumeImageMetadata holds map of key-value pairs describing the image associated with the volume
+	VolumeImageMetadata map[string]interface{} `json:"volume_image_metadata"`
 }
 
 /*

--- a/openstack/compute/v2/servers/results.go
+++ b/openstack/compute/v2/servers/results.go
@@ -164,6 +164,12 @@ type Server struct {
 	AdminPass string `json:"adminPass"`
 	// SecurityGroups includes the security groups that this instance has applied to it
 	SecurityGroups []map[string]interface{} `json:"security_groups"`
+	// Host refers to the name of the host
+	Host string `json:"OS-EXT-SRV-ATTR:host"`
+	// HostName refers to the hypervisor host name
+	HostName string `json:"OS-EXT-SRV-ATTR:hypervisor_hostname"`
+	// Volumes attached to the server
+	Volumes []interface{} `json:"os-extended-volumes:volumes_attached"`
 }
 
 func (s *Server) UnmarshalJSON(b []byte) error {

--- a/openstack/orchestration/v1/stackresources/results.go
+++ b/openstack/orchestration/v1/stackresources/results.go
@@ -9,18 +9,18 @@ import (
 
 // Resource represents a stack resource.
 type Resource struct {
-	Attributes   map[string]interface{}     `json:"attributes"`
-	CreationTime gophercloud.JSONRFC3339NoZ `json:"creation_time"`
-	Description  string                     `json:"description"`
-	Links        []gophercloud.Link         `json:"links"`
-	LogicalID    string                     `json:"logical_resource_id"`
-	Name         string                     `json:"resource_name"`
-	PhysicalID   string                     `json:"physical_resource_id"`
-	RequiredBy   []interface{}              `json:"required_by"`
-	Status       string                     `json:"resource_status"`
-	StatusReason string                     `json:"resource_status_reason"`
-	Type         string                     `json:"resource_type"`
-	UpdatedTime  gophercloud.JSONRFC3339NoZ `json:"updated_time"`
+	Attributes map[string]interface{} `json:"attributes"`
+	// CreationTime gophercloud.JSONRFC3339NoZ `json:"creation_time"`
+	Description  string             `json:"description"`
+	Links        []gophercloud.Link `json:"links"`
+	LogicalID    string             `json:"logical_resource_id"`
+	Name         string             `json:"resource_name"`
+	PhysicalID   string             `json:"physical_resource_id"`
+	RequiredBy   []interface{}      `json:"required_by"`
+	Status       string             `json:"resource_status"`
+	StatusReason string             `json:"resource_status_reason"`
+	Type         string             `json:"resource_type"`
+	// UpdatedTime  gophercloud.JSONRFC3339NoZ `json:"updated_time"`
 }
 
 // FindResult represents the result of a Find operation.

--- a/openstack/orchestration/v1/stacks/requests.go
+++ b/openstack/orchestration/v1/stacks/requests.go
@@ -218,7 +218,7 @@ type ListOptsBuilder interface {
 // by a particular network attribute. SortDir sets the direction, and is either
 // `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	Status  string  `q:"status"`
+	Status  string  `q:"stack_status"`
 	Name    string  `q:"name"`
 	Marker  string  `q:"marker"`
 	Limit   int     `q:"limit"`

--- a/openstack/orchestration/v1/stacks/results.go
+++ b/openstack/orchestration/v1/stacks/results.go
@@ -47,15 +47,15 @@ func (r StackPage) IsEmpty() (bool, error) {
 
 // ListedStack represents an element in the slice extracted from a List operation.
 type ListedStack struct {
-	CreationTime gophercloud.JSONRFC3339NoZ `json:"creation_time"`
-	Description  string                     `json:"description"`
-	ID           string                     `json:"id"`
-	Links        []gophercloud.Link         `json:"links"`
-	Name         string                     `json:"stack_name"`
-	Status       string                     `json:"stack_status"`
-	StatusReason string                     `json:"stack_status_reason"`
-	Tags         []string                   `json:"tags"`
-	UpdatedTime  gophercloud.JSONRFC3339NoZ `json:"updated_time"`
+	CreationTime gophercloud.JSONRFC3339 `json:"creation_time"`
+	Description  string                  `json:"description"`
+	ID           string                  `json:"id"`
+	Links        []gophercloud.Link      `json:"links"`
+	Name         string                  `json:"stack_name"`
+	Status       string                  `json:"stack_status"`
+	StatusReason string                  `json:"stack_status_reason"`
+	Tags         []string                `json:"tags"`
+	// UpdatedTime  gophercloud.JSONRFC3339NoZ `json:"updated_time"`
 }
 
 // ExtractStacks extracts and returns a slice of ListedStack. It is used while iterating
@@ -70,22 +70,22 @@ func ExtractStacks(r pagination.Page) ([]ListedStack, error) {
 
 // RetrievedStack represents the object extracted from a Get operation.
 type RetrievedStack struct {
-	Capabilities        []interface{}              `json:"capabilities"`
-	CreationTime        gophercloud.JSONRFC3339NoZ `json:"creation_time"`
-	Description         string                     `json:"description"`
-	DisableRollback     bool                       `json:"disable_rollback"`
-	ID                  string                     `json:"id"`
-	Links               []gophercloud.Link         `json:"links"`
-	NotificationTopics  []interface{}              `json:"notification_topics"`
-	Outputs             []map[string]interface{}   `json:"outputs"`
-	Parameters          map[string]string          `json:"parameters"`
-	Name                string                     `json:"stack_name"`
-	Status              string                     `json:"stack_status"`
-	StatusReason        string                     `json:"stack_status_reason"`
-	Tags                []string                   `json:"tags"`
-	TemplateDescription string                     `json:"template_description"`
-	Timeout             int                        `json:"timeout_mins"`
-	UpdatedTime         gophercloud.JSONRFC3339NoZ `json:"updated_time"`
+	Capabilities []interface{} `json:"capabilities"`
+	// CreationTime        gophercloud.JSONRFC3339NoZ `json:"creation_time"`
+	Description         string                   `json:"description"`
+	DisableRollback     bool                     `json:"disable_rollback"`
+	ID                  string                   `json:"id"`
+	Links               []gophercloud.Link       `json:"links"`
+	NotificationTopics  []interface{}            `json:"notification_topics"`
+	Outputs             []map[string]interface{} `json:"outputs"`
+	Parameters          map[string]string        `json:"parameters"`
+	Name                string                   `json:"stack_name"`
+	Status              string                   `json:"stack_status"`
+	StatusReason        string                   `json:"stack_status_reason"`
+	Tags                []string                 `json:"tags"`
+	TemplateDescription string                   `json:"template_description"`
+	Timeout             int                      `json:"timeout_mins"`
+	// UpdatedTime         gophercloud.JSONRFC3339NoZ `json:"updated_time"`
 }
 
 // GetResult represents the result of a Get operation.

--- a/openstack/orchestration/v1/stacks/results.go
+++ b/openstack/orchestration/v1/stacks/results.go
@@ -47,14 +47,14 @@ func (r StackPage) IsEmpty() (bool, error) {
 
 // ListedStack represents an element in the slice extracted from a List operation.
 type ListedStack struct {
-	CreationTime gophercloud.JSONRFC3339 `json:"creation_time"`
-	Description  string                  `json:"description"`
-	ID           string                  `json:"id"`
-	Links        []gophercloud.Link      `json:"links"`
-	Name         string                  `json:"stack_name"`
-	Status       string                  `json:"stack_status"`
-	StatusReason string                  `json:"stack_status_reason"`
-	Tags         []string                `json:"tags"`
+	// CreationTime gophercloud.JSONRFC3339 `json:"creation_time"`
+	Description  string             `json:"description"`
+	ID           string             `json:"id"`
+	Links        []gophercloud.Link `json:"links"`
+	Name         string             `json:"stack_name"`
+	Status       string             `json:"stack_status"`
+	StatusReason string             `json:"stack_status_reason"`
+	Tags         []string           `json:"tags"`
 	// UpdatedTime  gophercloud.JSONRFC3339NoZ `json:"updated_time"`
 }
 

--- a/results.go
+++ b/results.go
@@ -127,26 +127,6 @@ func (r HeaderResult) ExtractInto(to interface{}) error {
 	return err
 }
 
-// RFC3339 describes a common time format used by some API responses.
-const RFC3339 = "2006-01-02T15:04:05Z"
-
-type JSONRFC3339 time.Time
-
-func (jt *JSONRFC3339) UnmarshalJSON(data []byte) error {
-	b := bytes.NewBuffer(data)
-	dec := json.NewDecoder(b)
-	var s string
-	if err := dec.Decode(&s); err != nil {
-		return err
-	}
-	t, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		return err
-	}
-	*jt = JSONRFC3339(t)
-	return nil
-}
-
 // RFC3339Milli describes a common time format used by some API responses.
 const RFC3339Milli = "2006-01-02T15:04:05.999999Z"
 

--- a/results.go
+++ b/results.go
@@ -127,6 +127,26 @@ func (r HeaderResult) ExtractInto(to interface{}) error {
 	return err
 }
 
+// RFC3339 describes a common time format used by some API responses.
+const RFC3339 = "2006-01-02T15:04:05Z"
+
+type JSONRFC3339 time.Time
+
+func (jt *JSONRFC3339) UnmarshalJSON(data []byte) error {
+	b := bytes.NewBuffer(data)
+	dec := json.NewDecoder(b)
+	var s string
+	if err := dec.Decode(&s); err != nil {
+		return err
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return err
+	}
+	*jt = JSONRFC3339(t)
+	return nil
+}
+
 // RFC3339Milli describes a common time format used by some API responses.
 const RFC3339Milli = "2006-01-02T15:04:05.999999Z"
 


### PR DESCRIPTION
- Added host and volume related fields.
- Removed `CreationTime` and `UpdatedTime` fields from orchestration structs since the time format spec isn't compatible with our OpenStack system.  This is a temporary measure.  The upstream gophercloud repo has an outstanding issue created that should address this issue.  https://github.com/gophercloud/gophercloud/issues/75
