### PR TITLE
Added paging support to blockstorage v2

### DIFF
--- a/openstack/blockstorage/v2/volumes/requests.go
+++ b/openstack/blockstorage/v2/volumes/requests.go
@@ -111,7 +111,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 	}
 
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
-		return VolumePage{pagination.SinglePageBase(r)}
+		return VolumePage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
 

--- a/openstack/blockstorage/v2/volumes/results.go
+++ b/openstack/blockstorage/v2/volumes/results.go
@@ -71,13 +71,25 @@ TenantID string `json:"os-vol-tenant-attr:tenant_id"`
 
 // VolumePage is a pagination.pager that is returned from a call to the List function.
 type VolumePage struct {
-	pagination.SinglePageBase
+	pagination.LinkedPageBase
 }
 
 // IsEmpty returns true if a ListResult contains no Volumes.
 func (r VolumePage) IsEmpty() (bool, error) {
 	volumes, err := ExtractVolumes(r)
 	return len(volumes) == 0, err
+}
+
+// NextPageURL uses the response's embedded link reference to navigate to the next page of results.
+func (page VolumePage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"volumes_links"`
+	}
+	err := page.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
 }
 
 // ExtractVolumes extracts and returns Volumes. It is used while iterating over a volumes.List call.


### PR DESCRIPTION
Prior to this enhancement, only a single page (1000 volumes) was being retrieved.