### PR TITLE
Fixes to imageservice

### DIFF
--- a/openstack/imageservice/v2/images/results.go
+++ b/openstack/imageservice/v2/images/results.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/gophercloud/gophercloud"
@@ -77,6 +78,18 @@ type Image struct {
 
 	// Schema is the path to the JSON-schema that represent the image or image entity.
 	Schema string `json:"schema"`
+
+	// VirtualSize of the image.
+	VirtualSize int64 `json:"virtual_size"`
+
+	// Self is the URL for the virtual machine image.
+	Self string `json:"self"`
+
+	// DirectURL is the URL to access the image file kept in external store.
+	DirectURL string `json:"direct_url"`
+
+	// Locations is a list of objects, each of which describes an image location.
+	Locations []string `json:"locations"`
 }
 
 func (s *Image) UnmarshalJSON(b []byte) error {
@@ -109,7 +122,69 @@ func (s *Image) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	s.UpdatedAt, err = time.Parse(time.RFC3339, p.UpdatedAt)
+
+	// TODO: This should be removed once the Image API groups custom properties
+	// under a "properties" object.
+	err = s.unmarshalCustomProperties(b, p)
 	return err
+}
+
+// jsonTagKeys gets a list of JSON tag keys defined for the given struct.
+func jsonTagKeys(s interface{}) []string {
+	t := reflect.TypeOf(s).Elem()
+	keys := make([]string, 0, t.NumField())
+	for i := 0; i < t.NumField(); i++ {
+		var key string
+		field := t.Field(i)
+		if tagValue, ok := field.Tag.Lookup("json"); ok {
+			key = strings.Split(tagValue, ",")[0]
+			if key == "-" {
+				continue
+			}
+		}
+		if key == "" {
+			// not specified so use field name
+			key = strings.ToLower(field.Name)
+		}
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+// unmarshalCustomProperties parses the JSON-encoded custom properties and
+// stores the result in the Image.Properties field.
+//
+// The OpenStack API allows custom key:value properties to be specified
+// when creating images.  As of the Newton release, these custom properties
+// are not contained within an explicit "properties" JSON object.  Rather,
+// they are key:value pairs within the top level JSON response object.
+// Therefore, this function is needed to group all the custom properties
+// into the Image.Properties field for easy access by clients.
+func (s *Image) unmarshalCustomProperties(b []byte, st interface{}) error {
+	// Store custom properties that appear as top level JSON key:value pairs.
+	custom := make(map[string]interface{})
+	err := json.Unmarshal(b, &custom)
+	if err != nil {
+		return err
+	}
+	// custom map now holds every key:value pair of the response so filter out
+	// all known fields in Image
+	fields := jsonTagKeys((*Image)(nil))
+	// Filter out additional keys from modified struct
+	fields = append(fields, jsonTagKeys(st)...)
+	// Remove known fields so only custom properties remain
+	for _, field := range fields {
+		delete(custom, field)
+	}
+	// At this point, custom map should only contain custom properties so update
+	// the Image.Properties field.
+	s.Properties = make(map[string]string)
+	for k, v := range custom {
+		if value, ok := v.(string); ok {
+			s.Properties[k] = value
+		}
+	}
+	return nil
 }
 
 type commonResult struct {

--- a/openstack/imageservice/v2/images/testing/fixtures.go
+++ b/openstack/imageservice/v2/images/testing/fixtures.go
@@ -143,9 +143,9 @@ func HandleImageListSuccessfully(t *testing.T) {
 		fmt.Fprintf(w, strings.Join(imageJSON, ","))
 
 		fmt.Fprintf(w, `],
-			    "next": "/images?marker=%s&limit=%v",
-			    "schema": "/schemas/images",
-			    "first": "/images?limit=%v"}`, newMarker, limit, limit)
+			    "next": "/v2/images?marker=%s&limit=%v",
+			    "schema": "/v2/schemas/images",
+			    "first": "/v2/images?limit=%v"}`, newMarker, limit, limit)
 
 	})
 }
@@ -161,7 +161,8 @@ func HandleImageCreationSuccessfully(t *testing.T) {
 			"tags": [
 				"ubuntu",
 				"quantal"
-			]
+			],
+			"foo": "bar"
 		}`)
 
 		w.WriteHeader(http.StatusCreated)
@@ -186,7 +187,8 @@ func HandleImageCreationSuccessfully(t *testing.T) {
 			"schema": "/v2/schemas/image",
 			"size": 0,
 			"checksum": "",
-			"virtual_size": 0
+			"virtual_size": 0,
+			"properties": {"foo": "bar"}
 		}`)
 	})
 }
@@ -260,7 +262,7 @@ func HandleImageGetSuccessfully(t *testing.T) {
 			"size": 13167616,
 			"min_ram": 0,
 			"schema": "/v2/schemas/image",
-			"virtual_size": "None"
+			"virtual_size": null
 		}`)
 	})
 }

--- a/openstack/imageservice/v2/images/testing/requests_test.go
+++ b/openstack/imageservice/v2/images/testing/requests_test.go
@@ -31,7 +31,13 @@ func TestListImage(t *testing.T) {
 		}
 
 		for _, i := range images {
-			t.Logf("%s\t%s\t%s\t%s\t%v\t\n", i.ID, i.Name, i.Owner, i.Checksum, i.SizeBytes)
+			t.Logf("%s\t%s\t%s\t%s\t%v\t%+v\n", i.ID, i.Name, i.Owner,
+				i.Checksum, i.SizeBytes, i.Properties)
+			if i.ID == "07aa21a9-fa1a-430e-9a33-185be5982431" {
+				th.AssertEquals(t, 2, len(i.Properties))
+			} else {
+				th.AssertEquals(t, 0, len(i.Properties))
+			}
 			count++
 		}
 
@@ -57,6 +63,9 @@ func TestCreateImage(t *testing.T) {
 		ID:   id,
 		Name: name,
 		Tags: []string{"ubuntu", "quantal"},
+		Properties: map[string]string{
+			"foo": "bar",
+		},
 	}).Extract()
 
 	th.AssertNoErr(t, err)
@@ -70,6 +79,8 @@ func TestCreateImage(t *testing.T) {
 	createdDate := actualImage.CreatedAt
 	lastUpdate := actualImage.UpdatedAt
 	schema := "/v2/schemas/image"
+	self := "/v2/images/e7db3b45-8db7-47ad-8109-3fb55c2c24fd"
+	properties := map[string]string{"foo": "bar"}
 
 	expectedImage := images.Image{
 		ID:   "e7db3b45-8db7-47ad-8109-3fb55c2c24fd",
@@ -91,6 +102,9 @@ func TestCreateImage(t *testing.T) {
 		CreatedAt:  createdDate,
 		UpdatedAt:  lastUpdate,
 		Schema:     schema,
+
+		Self:       self,
+		Properties: properties,
 	}
 
 	th.AssertDeepEquals(t, &expectedImage, actualImage)
@@ -122,6 +136,7 @@ func TestCreateImageNulls(t *testing.T) {
 	createdDate := actualImage.CreatedAt
 	lastUpdate := actualImage.UpdatedAt
 	schema := "/v2/schemas/image"
+	self := "/v2/images/e7db3b45-8db7-47ad-8109-3fb55c2c24fd"
 
 	expectedImage := images.Image{
 		ID:   "e7db3b45-8db7-47ad-8109-3fb55c2c24fd",
@@ -143,6 +158,7 @@ func TestCreateImageNulls(t *testing.T) {
 		CreatedAt:  createdDate,
 		UpdatedAt:  lastUpdate,
 		Schema:     schema,
+		Self:       self,
 	}
 
 	th.AssertDeepEquals(t, &expectedImage, actualImage)
@@ -169,6 +185,7 @@ func TestGetImage(t *testing.T) {
 	createdDate := actualImage.CreatedAt
 	lastUpdate := actualImage.UpdatedAt
 	schema := "/v2/schemas/image"
+	self := "/v2/images/1bea47ed-f6a9-463b-b423-14b9cca9ad27"
 
 	expectedImage := images.Image{
 		ID:   "1bea47ed-f6a9-463b-b423-14b9cca9ad27",
@@ -194,6 +211,9 @@ func TestGetImage(t *testing.T) {
 		CreatedAt: createdDate,
 		UpdatedAt: lastUpdate,
 		Schema:    schema,
+		Self:      self,
+
+		Properties: map[string]string{},
 	}
 
 	th.AssertDeepEquals(t, &expectedImage, actualImage)
@@ -228,6 +248,7 @@ func TestUpdateImage(t *testing.T) {
 	createdDate := actualImage.CreatedAt
 	lastUpdate := actualImage.UpdatedAt
 	schema := "/v2/schemas/image"
+	self := "/v2/images/da3b75d9-3f4a-40e7-8a2c-bfab23927dea"
 
 	expectedImage := images.Image{
 		ID:         "da3b75d9-3f4a-40e7-8a2c-bfab23927dea",
@@ -253,6 +274,8 @@ func TestUpdateImage(t *testing.T) {
 		CreatedAt:       createdDate,
 		UpdatedAt:       lastUpdate,
 		Schema:          schema,
+		Self:            self,
+		Properties:      map[string]string{},
 	}
 
 	th.AssertDeepEquals(t, &expectedImage, actualImage)

--- a/openstack/imageservice/v2/images/urls.go
+++ b/openstack/imageservice/v2/images/urls.go
@@ -39,6 +39,14 @@ func deleteURL(c *gophercloud.ServiceClient, imageID string) string {
 
 // builds next page full url based on current url
 func nextPageURL(currentURL string, next string) string {
+	if next == "" {
+		return next
+	}
 	base := currentURL[:strings.Index(currentURL, "/images")]
+	// The next URL may contain the version (i.e., /v2/images). Exclude it if so.
+	idx := strings.Index(next, "/images")
+	if idx != -1 {
+		next = next[idx:]
+	}
 	return base + next
 }


### PR DESCRIPTION
- Support for unmarshaling of custom image properties.
- Prevent `404` caused by duplicate image API version in next page URLs.