### PR TITLE
Remove 'locations' from image result

### DIFF
--- a/openstack/imageservice/v2/images/results.go
+++ b/openstack/imageservice/v2/images/results.go
@@ -92,9 +92,6 @@ type Image struct {
 
 	// DirectURL is the URL to access the image file kept in external store.
 	DirectURL string `json:"direct_url"`
-
-	// Locations is a list of objects, each of which describes an image location.
-	Locations []string `json:"locations"`
 }
 
 func (r *Image) UnmarshalJSON(b []byte) error {


### PR DESCRIPTION
Remove the image `locations` property since it isn't officially part of the upstream gophercloud repo.  It may have been inadvertently added in a prior commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/gophercloud/15)
<!-- Reviewable:end -->
